### PR TITLE
register sieve transformations in unified inventory if it exists

### DIFF
--- a/gravelsieve/api.lua
+++ b/gravelsieve/api.lua
@@ -46,6 +46,7 @@ function gravelsieve.api.reset_config()
     process_totals = {}
 end
 
+local unified_inventory_enabled = minetest.global_exists("unified_inventory")
 local function clear_unified_inventory_craft(input_name, output_name)
     local crafts = unified_inventory.crafts_for.recipe[ItemStack(output_name):get_name()]
     if crafts then
@@ -133,7 +134,7 @@ function gravelsieve.api.remove_input(input_name)
     end
 
     local output = processes[input_name]
-    if minetest.global_exists("unified_inventory") then
+    if unified_inventory_enabled then
         for output_type, type_outputs in pairs(output) do
             for output_name,_ in pairs(type_outputs) do
                 clear_unified_inventory_craft(input_name, output_name)
@@ -225,7 +226,7 @@ function gravelsieve.api.register_output(input_name, output_name, probability, o
         process_totals[input_name][output_type] = process_totals[input_name][output_type] + probability
     end
 
-    if minetest.global_exists("unified_inventory") then
+    if unified_inventory_enabled then
         unified_inventory.register_craft({
             items = {input_name},
             output = output_name,
@@ -270,7 +271,7 @@ function gravelsieve.api.remove_output(input_name, output_name)
         process_totals[input_name][existing_type] = process_totals[input_name][existing_type] - existing_value
     end
 
-    if minetest.global_exists("unified_inventory") then
+    if unified_inventory_enabled then
         clear_unified_inventory_craft(input_name, output_name)
     end
 

--- a/gravelsieve/depends.txt
+++ b/gravelsieve/depends.txt
@@ -4,3 +4,4 @@ tubelib?
 hopper?
 pipeworks?
 test?
+unified_inventory?

--- a/gravelsieve/init.lua
+++ b/gravelsieve/init.lua
@@ -18,6 +18,15 @@ local function gs_dofile(filename)
     dofile(("%s/%s"):format(gravelsieve.modpath, filename))
 end
 
+if minetest.global_exists("unified_inventory") then
+	unified_inventory.register_craft_type("sieving", {
+		description = S("Sieving (by chance)"),
+		icon = "gravelsieve_sieve.png",
+		width = 1,
+		height = 1,
+	})
+end
+
 gs_dofile("settings.lua")
 gs_dofile("api.lua")
 gs_dofile("probability_api.lua")

--- a/gravelsieve/mod.conf
+++ b/gravelsieve/mod.conf
@@ -1,4 +1,4 @@
 name=gravelsieve
 description=Sieve gravel to find ores!
 depends=default
-optional_depends=moreblocks,tubelib,hopper,pipeworks,test
+optional_depends=moreblocks,tubelib,hopper,pipeworks,test,unified_inventory


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/313

Registers a new craft type with unified inventory, then registers and removes crafts of that type for each item registered with the sieve